### PR TITLE
fix minor spelling error

### DIFF
--- a/public/static/js/main-vue.js
+++ b/public/static/js/main-vue.js
@@ -90,7 +90,7 @@ Vue.filter('momentFromNow', function (value) {
 
 Vue.filter('momentUnixFromNow', function (value) {
   if(value == 0){
-    return 'Unkown'
+    return 'Unknown'
   }
   return moment.unix(value).fromNow();
 })


### PR DESCRIPTION
replaces `Unkown` with `Unknown` in the timestamp with no known date