### PR TITLE
Add link for Discord account

### DIFF
--- a/views/account/account.ejs
+++ b/views/account/account.ejs
@@ -267,7 +267,7 @@
       <li class="list-group-item">
         <i class="fab fa-twitter"></i> Twitter
         <span class="float-right">
-          <a href="https://twitter.com/<%= account.owner.twitter.username %>" target="_blank" rel="noreferer, noopener"
+          <a href="https://twitter.com/<%= account.owner.twitter.username %>"
             target="_blank" rel="noreferer, noopener">
             @<%= account.owner.twitter.username %>
           </a>
@@ -278,7 +278,7 @@
       <li class="list-group-item">
         <i class="fab fa-github"></i> GitHub
         <span class="float-right">
-          <a href="https://github.com/<%= account.owner.github.username %>" target="_blank" rel="noreferer, noopener"
+          <a href="https://github.com/<%= account.owner.github.username %>"
             target="_blank" rel="noreferer, noopener">
             <%= account.owner.github.username %>
           </a>
@@ -289,7 +289,7 @@
       <li class="list-group-item">
         <i class="fab fa-reddit"></i> Reddit
         <span class="float-right">
-          <a href="https://www.reddit.com/user/<%= account.owner.reddit.name %>" target="_blank" rel="noreferer, noopener"
+          <a href="https://www.reddit.com/user/<%= account.owner.reddit.name %>"
             target="_blank" rel="noreferer, noopener">
             <%= account.owner.reddit.name %>
           </a>
@@ -300,7 +300,10 @@
       <li class="list-group-item">
         <i class="fab fa-discord"></i> Discord
         <span class="float-right">
-          <%= account.owner.discord.username %>#<%= account.owner.discord.discriminator %>
+          <a href="https://discord.com/users/<%= account.owner.discord.id %>"
+            target="_blank" rel="noreferer, noopener">
+            <%= account.owner.discord.username %>#<%= account.owner.discord.discriminator %>
+          </a>
         </span>
       </li>
       <% } %>


### PR DESCRIPTION
This adds an `a` element to allow clicking on the discord tag.
Preview:
![e](https://i.lightcord.org/‌⁠‌​‌᠎‌᠎​​.gif)
Discord allows users popups with `https://discord.com/users/{user.id}`